### PR TITLE
Fixes for specific problematic dates

### DIFF
--- a/test/guess-date-test.js
+++ b/test/guess-date-test.js
@@ -140,6 +140,13 @@ describe('Guess Date', () => {
   describe('Mixed date and time', () => {
     test('6th December 2017 20:15', 'Wed, 06 Dec 2017 20:15:00 GMT')
   })
+
+  describe('Specific problematic dates', () => {
+    test('Sept 1', 'Wed, 01 Sep 2021 08:00:00 GMT', new Date(1630428420 * 1000)) // Tue Aug 31 2021 16:47:00 GMT
+    test('Sept 4', 'Sat, 04 Sep 2021 08:00:00 GMT', new Date(1630428420 * 1000)) // Tue Aug 31 2021 16:47:00 GMT
+    test('Sat', 'Sat, 04 Sep 2021 08:00:00 GMT', new Date(1630428420 * 1000)) // Tue Aug 31 2021 16:47:00 GMT
+    test('April 2nd', 'Sat, 02 Apr 2022 08:00:00 GMT', new Date(1648726740 * 1000)) // Thu Mar 31 2022 11:39:00 GMT
+  })
 })
 
 function logTestResults () {

--- a/test/guess-date-tests.json
+++ b/test/guess-date-tests.json
@@ -566,5 +566,37 @@
     "section": "Mixed date and time",
     "title": "should match '6th December 2017 20:15' as Wed, 06 Dec 2017 20:15:00 GMT",
     "actual": "Wed, 06 Dec 2017 20:15:00 GMT"
+  },
+  {
+    "referenceTime": "2021-08-31T16:47:00.000Z",
+    "input": "Sept 1",
+    "expected": "Wed, 01 Sep 2021 08:00:00 GMT",
+    "section": "Specific problematic dates",
+    "title": "should match 'Sept 1' as Wed, 01 Sep 2021 08:00:00 GMT",
+    "actual": "Wed, 01 Sep 2021 08:00:00 GMT"
+  },
+  {
+    "referenceTime": "2021-08-31T16:47:00.000Z",
+    "input": "Sept 4",
+    "expected": "Sat, 04 Sep 2021 08:00:00 GMT",
+    "section": "Specific problematic dates",
+    "title": "should match 'Sept 4' as Sat, 04 Sep 2021 08:00:00 GMT",
+    "actual": "Sat, 04 Sep 2021 08:00:00 GMT"
+  },
+  {
+    "referenceTime": "2021-08-31T16:47:00.000Z",
+    "input": "Sat",
+    "expected": "Sat, 04 Sep 2021 08:00:00 GMT",
+    "section": "Specific problematic dates",
+    "title": "should match 'Sat' as Sat, 04 Sep 2021 08:00:00 GMT",
+    "actual": "Sat, 04 Sep 2021 08:00:00 GMT"
+  },
+  {
+    "referenceTime": "2022-03-31T11:39:00.000Z",
+    "input": "April 2nd",
+    "expected": "Sat, 02 Apr 2022 08:00:00 GMT",
+    "section": "Specific problematic dates",
+    "title": "should match 'April 2nd' as Sat, 02 Apr 2022 08:00:00 GMT",
+    "actual": "Sat, 02 Apr 2022 08:00:00 GMT"
   }
 ]

--- a/test/guess-date-tests.md
+++ b/test/guess-date-tests.md
@@ -133,3 +133,12 @@ guessDate(now, '21:03:30')                 // Sun, 12 Feb 2017 21:03:30 GMT
 ```js
 guessDate(now, '6th December 2017 20:15')  // Wed, 06 Dec 2017 20:15:00 GMT
 ```
+
+### Specific problematic dates
+
+```js
+guessDate(now, 'Sept 1')                   // Wed, 01 Sep 2021 08:00:00 GMT
+guessDate(now, 'Sept 4')                   // Sat, 04 Sep 2021 08:00:00 GMT
+guessDate(now, 'Sat')                      // Sat, 04 Sep 2021 08:00:00 GMT
+guessDate(now, 'April 2nd')                // Sat, 02 Apr 2022 08:00:00 GMT
+```


### PR DESCRIPTION
This fixes some small bugs I've encountered while using this library.

- When using "next ..." in a timezone that's ahead of GMT it would return the day after the day asked for.
- With empty input it would apply a timezone offset and claim it's GMT.
- Guessing a date in the next month while the date is 31st caused skipping a month (test cases added).

Guessdate has been extremely useful for me, thank you for the great work!